### PR TITLE
Upgrade to Feathers Buzzard (v3)

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -1,4 +1,4 @@
-const errors = require('feathers-errors');
+const errors = require('@feathersjs/errors');
 
 module.exports = function errorHandler (error) {
   let feathersError = error;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,7 @@
 const Proto = require('uberproto');
-const filter = require('feathers-query-filters');
+const { filterQuery } = require('@feathersjs/commons');
 const isPlainObject = require('is-plain-object');
-
-const {
-  errors
-} = require('feathers-errors');
+const errors = require('@feathersjs/errors');
 
 const errorHandler = require('./error-handler');
 const hooks = require('./hooks');
@@ -113,7 +110,7 @@ class Service {
   }
 
   createQuery (params = {}) {
-    const { filters, query } = filter(params.query || {});
+    const { filters, query } = filterQuery(params.query || {});
     let q = this.db(params).select([`${this.table}.*`]);
 
     // $select uses a specific find syntax, so it has to come first.
@@ -134,7 +131,7 @@ class Service {
     return q;
   }
 
-  _find (params, count, getFilter = filter) {
+  _find (params, count, getFilter = filterQuery) {
     const { filters, query } = getFilter(params.query || {});
     const q = params.knex || this.createQuery(params);
 
@@ -184,7 +181,7 @@ class Service {
   find (params) {
     const paginate = (params && typeof params.paginate !== 'undefined') ? params.paginate : this.paginate;
     const result = this._find(params, !!paginate.default,
-      query => filter(query, paginate)
+      query => filterQuery(query, paginate)
     );
 
     if (!paginate.default) {
@@ -229,7 +226,7 @@ class Service {
   }
 
   patch (id, raw, params) {
-    const query = filter(params.query || {}).query;
+    const query = filterQuery(params.query || {}).query;
     const data = Object.assign({}, raw);
     const mapIds = page => page.data.map(current => current[this.id]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,44 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@feathersjs/commons": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-1.3.0.tgz",
+      "integrity": "sha512-/2Fevm/g0hIe79A81eMOScPNtoWIuHk1LwXCLJGeuGKoTUnzd/xJLSFesSq7dlePDtwMtuR8apnB1CM49iCy+g=="
+    },
+    "@feathersjs/errors": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@feathersjs/errors/-/errors-3.2.0.tgz",
+      "integrity": "sha512-4xsE7OyzxGvs2hyG19nf2qb4rV2nWoWbQ6/FnDIYrNHi7M9kOy+deLwNhKnXa4r/hg3xf+AVpC8kBjUQjWYWHA==",
+      "requires": {
+        "debug": "3.1.0"
+      }
+    },
+    "@feathersjs/express": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@feathersjs/express/-/express-1.1.2.tgz",
+      "integrity": "sha512-oxXZs3QAZB80fBajb7nh3Pbongm8ESXVnJw1EuX7fui4JOXh2qGw9hf8e3xKAZ/fmkHmgofdA1A3iqIzBg3Isw==",
+      "dev": true,
+      "requires": {
+        "@feathersjs/commons": "1.3.0",
+        "@feathersjs/errors": "3.2.0",
+        "debug": "3.1.0",
+        "express": "4.16.2",
+        "uberproto": "1.2.0"
+      }
+    },
+    "@feathersjs/feathers": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@feathersjs/feathers/-/feathers-3.0.1.tgz",
+      "integrity": "sha512-uRvzpnpwdW31+hQ67sGPQAQm09hmZrw1nc5om9yoSTouszjREcM2qusJkyWXN67/8Uythge6OjlYIP0NFJHVaw==",
+      "dev": true,
+      "requires": {
+        "@feathersjs/commons": "1.3.0",
+        "debug": "3.1.0",
+        "events": "1.1.1",
+        "uberproto": "1.2.0"
+      }
+    },
     "abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -1333,18 +1371,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "setprototypeof": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-          "dev": true
-        },
-        "statuses": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
-          "dev": true
         }
       }
     },
@@ -1386,64 +1412,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
-    },
-    "feathers": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/feathers/-/feathers-2.2.3.tgz",
-      "integrity": "sha512-p2dgIbhD5IBZRN2At2hahg0KHnyRLIL0sQE+5Ci+GlAHPEQtAVUSgfWqTAOMiNFelHUqlFZSREnXH0VsuV3NOw==",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "debug": "3.1.0",
-        "events": "1.1.1",
-        "express": "4.16.2",
-        "feathers-commons": "0.8.7",
-        "rubberduck": "1.1.1",
-        "uberproto": "1.2.0"
-      }
-    },
-    "feathers-commons": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/feathers-commons/-/feathers-commons-0.8.7.tgz",
-      "integrity": "sha1-EcbyW1N3RamD6NYVUtfbiTLVN4I="
-    },
-    "feathers-errors": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/feathers-errors/-/feathers-errors-2.9.2.tgz",
-      "integrity": "sha512-qwIX97bNW7+1tWVG073+omUA0rCYKJtTtwuzTrrvfrtdr8J8Dk1Fy4iaV9Fa6/YBD5AZu0lsplPE0iu4u/d4GQ==",
-      "requires": {
-        "debug": "3.1.0"
-      }
-    },
-    "feathers-hooks": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/feathers-hooks/-/feathers-hooks-2.1.2.tgz",
-      "integrity": "sha512-XQKhbo4d4TuXyco+tbHmKn5wo8QhdSNslJ/+zckNYfUzLmrN8L3uB4Utf0/ivcgwWxJtS1kVhEETBN4TDxuWFg==",
-      "dev": true,
-      "requires": {
-        "feathers-commons": "0.8.7",
-        "uberproto": "1.2.0"
-      }
-    },
-    "feathers-query-filters": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/feathers-query-filters/-/feathers-query-filters-2.1.2.tgz",
-      "integrity": "sha1-zbGCJNteGcwBQNUoEI4JCNXrBlQ=",
-      "requires": {
-        "feathers-commons": "0.8.7"
-      }
-    },
-    "feathers-rest": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/feathers-rest/-/feathers-rest-1.8.1.tgz",
-      "integrity": "sha512-FYVcBQLGocSdpjxEf+E/9Cb0QAX0S+biqRgB5KAGpoAF51cou9LV0WW1IwqwHzAT67KRyS4dT7fVCrE4kisM2w==",
-      "dev": true,
-      "requires": {
-        "debug": "3.1.0",
-        "feathers-commons": "0.8.7",
-        "feathers-errors": "2.9.2",
-        "qs": "6.5.1"
-      }
     },
     "feathers-service-tests": {
       "version": "0.10.2",
@@ -1575,12 +1543,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "statuses": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
-          "dev": true
         }
       }
     },
@@ -1956,7 +1918,15 @@
         "depd": "1.1.1",
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
-        "statuses": "1.4.0"
+        "statuses": "1.3.1"
+      },
+      "dependencies": {
+        "setprototypeof": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+          "dev": true
+        }
       }
     },
     "http-signature": {
@@ -3512,12 +3482,6 @@
         "glob": "7.1.2"
       }
     },
-    "rubberduck": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/rubberduck/-/rubberduck-1.1.1.tgz",
-      "integrity": "sha1-zSzaS4ZxeBNer8mVpxOE9fdD2wI=",
-      "dev": true
-    },
     "run-async": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
@@ -3598,12 +3562,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "statuses": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
-          "dev": true
         }
       }
     },
@@ -3620,9 +3578,9 @@
       }
     },
     "setprototypeof": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
       "dev": true
     },
     "shelljs": {
@@ -4525,9 +4483,9 @@
       }
     },
     "statuses": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
       "dev": true
     },
     "stealthy-require": {

--- a/package.json
+++ b/package.json
@@ -51,18 +51,17 @@
     "lib": "lib"
   },
   "dependencies": {
-    "debug": "^3.0.0",
-    "feathers-errors": "^2.0.1",
-    "feathers-query-filters": "^2.0.0",
+    "@feathersjs/commons": "^1.3.0",
+    "@feathersjs/errors": "^3.2.0",
+    "debug": "^3.1.0",
     "is-plain-object": "^2.0.1",
     "uberproto": "^1.2.0"
   },
   "devDependencies": {
+    "@feathersjs/express": "^1.1.2",
+    "@feathersjs/feathers": "^3.0.1",
     "body-parser": "^1.14.1",
     "chai": "^4.0.0",
-    "feathers": "^2.0.0-pre.4",
-    "feathers-hooks": "^2.0.2",
-    "feathers-rest": "^1.3.0",
     "feathers-service-tests": "^0.10.0",
     "istanbul": "^1.1.0-alpha.1",
     "knex": "^0.14.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,11 +1,10 @@
 const { expect } = require('chai');
 const assert = require('assert');
-const feathers = require('feathers');
-const hooks = require('feathers-hooks');
+const feathers = require('@feathersjs/feathers');
 const knex = require('knex');
 
 const { base } = require('feathers-service-tests');
-const { errors } = require('feathers-errors');
+const errors = require('@feathersjs/errors');
 
 const service = require('../lib');
 
@@ -54,7 +53,6 @@ function clean () {
 
 describe('Feathers Knex Service', () => {
   const app = feathers()
-    .configure(hooks())
     .hooks({
       before: transaction.start(),
       after: transaction.end(),


### PR DESCRIPTION
This updates the development dependencies to Feathers Buzzard. New release will stay compatible with previous versions of Feathers.

Previous versions of `feathers-knex` are also compatible with Feathers Buzzard.