### PR TITLE
Pass function to then() to remove warning

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -38,7 +38,7 @@ const end = (options) => {
 
       return trx.commit()
         .then(() => debug('finished transaction %s with success', id))
-        .then(hook);
+        .then(() => hook);
     }
     return hook;
   };
@@ -50,7 +50,7 @@ const rollback = (options) => {
       const { trx, id } = hook.params.transaction;
       return trx.rollback()
         .then(() => debug('rolling back transaction %s', id))
-        .then(hook);
+        .then(() => hook);
     }
     return hook;
   };


### PR DESCRIPTION
Pass function instead of object to then() to remove warning message, refer to #136 for details.