### PR TITLE
Add default sorting to $skip query if not set

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -139,10 +139,15 @@ class Service {
     if (filters.$limit) {
       q.limit(filters.$limit);
     }
-
+    
     // Handle $skip
     if (filters.$skip) {
       q.offset(filters.$skip);
+
+      // provide default sorting if its not set
+      if(!filters.$sort){
+        q.orderBy(this.id, 'asc');
+      }
     }
 
     let executeQuery = total => {


### PR DESCRIPTION
https://github.com/feathersjs-ecosystem/feathers-knex/issues/141

### Summary

Fixes an issue where sql server requires a order by parameter if offset ($skip) is used. 

If so, please mention them to keep the conversations linked together.

### Other Information

Adds a default sort parameter to the `idProp` if its not already set when using $skip parameters.