### PR TITLE
call update directly on knex instead of where.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -305,7 +305,7 @@ class Service {
       // NOTE (EK): Delete id field so we don't update it
       delete newObject[this.id];
 
-      return this.db(params).where(this.id, id).update(newObject).then(() => {
+      return this.db(params).update(newObject).where(this.id, id).then(() => {
         // NOTE (EK): Restore the id field so we can return it to the client
         newObject[this.id] = id;
         return newObject;


### PR DESCRIPTION
This change allows one to pass a middleware (instead of a knex object) that returns different knex
objects based on whatever it is an update/insert (write) or select
(read) to allow read-write replica setups.