### PR TITLE
Fixing count default sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,12 +247,13 @@ Combined with `.createQuery({ query: {...} })`, which returns a new KnexJS query
 app.service('mesages').hooks({
   before: {
     find(context) {
-      const query = this.createQuery({ query: context.params.query });
+      const query = this.createQuery(context.params);
 
       // do something with query here
       query.orderBy('name', 'desc');
 
       context.params.knex = query;
+      return context;
     }
   }
 });

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -48,7 +48,7 @@ const rollback = (options) => {
   return hook => {
     if (hook.params.transaction) {
       const { trx, id } = hook.params.transaction;
-      return trx.rollback()
+      return trx.rollback(hook.error)
         .then(() => debug('rolling back transaction %s', id))
         .then(() => hook);
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -179,10 +179,9 @@ class Service {
           .clearSelect()
           .count(`${this.table}.${this.id} as total`);
 
-      if(!params.knex)
-        this.knexify(countQuery, query);
+      if (!params.knex) { this.knexify(countQuery, query); }
 
-      return countQuery.then(count => count[0].total).then(executeQuery);
+      return countQuery.then(count => count[0].total).then(executeQuery).catch(errorHandler);
     }
 
     return executeQuery().catch(errorHandler);

--- a/lib/index.js
+++ b/lib/index.js
@@ -133,19 +133,19 @@ class Service {
 
   _find (params, count, getFilter = filterQuery) {
     const { filters, query } = getFilter(params.query || {});
-    const q = params.knex || this.createQuery(params);
+    const q = params.knex ? params.knex.clone() : this.createQuery(params);
 
     // Handle $limit
     if (filters.$limit) {
       q.limit(filters.$limit);
     }
-    
+
     // Handle $skip
     if (filters.$skip) {
       q.offset(filters.$skip);
 
       // provide default sorting if its not set
-      if(!filters.$sort){
+      if (!filters.$sort) {
         q.orderBy(this.id, 'asc');
       }
     }
@@ -175,11 +175,12 @@ class Service {
     if (count) {
       let countQuery =
         (params.knex || this.db(params))
-        .clone()
-        .clearSelect()
-        .count(`${this.table}.${this.id} as total`);
+          .clone()
+          .clearSelect()
+          .count(`${this.table}.${this.id} as total`);
 
-      this.knexify(countQuery, query);
+      if(!params.knex)
+        this.knexify(countQuery, query);
 
       return countQuery.then(count => count[0].total).then(executeQuery);
     }
@@ -243,7 +244,7 @@ class Service {
     // we create a list of the ids of all items that will be changed
     // to re-query them after the update
     const ids = id === null ? this._find(params)
-        .then(mapIds) : Promise.resolve([ id ]);
+      .then(mapIds) : Promise.resolve([ id ]);
 
     if (id !== null) {
       query[this.id] = id;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -109,7 +109,7 @@ describe('Feathers Knex Service', () => {
 
             // do something with query here
             query.orderBy('name', 'desc');
-            console.log(query.toSQL().toNative());
+            //console.log(query.toSQL().toNative());
 
             context.params.knex = query;
             return context;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -31,24 +31,28 @@ const peopleId = service({
 });
 
 function clean () {
-  return people.init({}, (table) => {
-    table.increments('id');
-    table.string('name');
-    table.integer('age');
-    table.integer('time');
-    table.boolean('created');
-    return table;
-  })
-  .then(() => {
-    return peopleId.init({}, (table) => {
-      table.increments('customid');
-      table.string('name');
-      table.integer('age');
-      table.integer('time');
-      table.boolean('created');
-      return table;
-    });
-  });
+  return Promise.all([
+    db.schema.dropTableIfExists('people').then(() => {
+      return people.init({}, (table) => {
+        table.increments('id');
+        table.string('name');
+        table.integer('age');
+        table.integer('time');
+        table.boolean('created');
+        return table;
+      });
+    }),
+    db.schema.dropTableIfExists('people-customid').then(() => {
+      return peopleId.init({}, (table) => {
+        table.increments('customid');
+        table.string('name');
+        table.integer('age');
+        table.integer('time');
+        table.boolean('created');
+        return table;
+      });
+    })
+  ]);
 }
 
 describe('Feathers Knex Service', () => {
@@ -93,6 +97,36 @@ describe('Feathers Knex Service', () => {
 
     base(app, errors, 'people');
     base(app, errors, 'people-customid', 'customid');
+  });
+
+  describe('custom queries', () => {
+    before(clean);
+    before(() => {
+      app.hooks({}).service('people').hooks({
+        before: {
+          find(context) {
+            const query = this.createQuery(context.params);
+
+            // do something with query here
+            query.orderBy('name', 'desc');
+            console.log(query.toSQL().toNative());
+
+            context.params.knex = query;
+            return context;
+          }
+        }
+      });
+    });
+    after(clean);
+    after(() => {
+      app.hooks({
+        before: transaction.start(),
+        after: transaction.end(),
+        error: transaction.rollback()
+      }).service('people').hooks({});
+    });
+
+    base(app, errors, 'people');
   });
 
   describe('$like method', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -104,12 +104,12 @@ describe('Feathers Knex Service', () => {
     before(() => {
       app.hooks({}).service('people').hooks({
         before: {
-          find(context) {
+          find (context) {
             const query = this.createQuery(context.params);
 
             // do something with query here
             query.orderBy('name', 'desc');
-            //console.log(query.toSQL().toNative());
+            // console.log(query.toSQL().toNative());
 
             context.params.knex = query;
             return context;


### PR DESCRIPTION
### Summary

Fixes issues with #141 and a few other small issues.

- Clones params.knex so the default orderBy doesn't cause an error when counting
- Creates a test scenario for customized params.knex so this doesn't break in the future
- Fixes rollback hook so the error information is not [undefined]
- Fixes documentation on customized queries