### PR TITLE
Do clearOrder() for countQuery

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -188,6 +188,7 @@ class Service {
         (params.knex || this.db(params))
           .clone()
           .clearSelect()
+          .clearOrder()
           .count(`${this.table}.${this.id} as total`);
 
       if (!params.knex) { this.knexify(countQuery, query); }


### PR DESCRIPTION
### Summary

When user overrides the orderBy in before.find hook it should be cleared for countQuery.