### PR TITLE
Add support for $and

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,27 @@ Run the example with `node app` and go to [localhost:3030/messages](http://local
 
 In addition to the [common querying mechanism](https://docs.feathersjs.com/api/databases/querying.html), this adapter also supports:
 
+### $and
+
+Find all records that match all of the given criteria. The following query retrieves all messages that have foo and bar attributes as true.
+
+```js
+app.service('messages').find({
+  query: {
+    $and: [
+      {foo: true},
+      {bar: true}
+    ]
+  }
+});
+```
+
+Through the REST API:
+
+```
+/messages?$and[][foo]=true&$and[][bar]=true
+```
+
 ### $like
 
 Find all records where the value matches the given string pattern. The following query retrieves all messages that start with `Hello`:

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ const debug = require('debug')('feathers-knex');
 
 const METHODS = {
   $or: 'orWhere',
+  $and: 'andWhere',
   $ne: 'whereNot',
   $in: 'whereIn',
   $nin: 'whereNotIn'
@@ -98,12 +99,12 @@ class Service {
       const operator = OPERATORS[key] || '=';
 
       if (method) {
-        if (key === '$or') {
+        if (key === '$or' || key === '$and') {
           const self = this;
 
           return query.where(function () {
             return value.forEach((condition) => {
-              this.orWhere(function () {
+              this[method](function () {
                 self.knexify(this, condition);
               });
             });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -229,6 +229,37 @@ describe('Feathers Knex Service', () => {
       });
     });
 
+    it('$and works properly', () => {
+      app.service('/people').create([{
+        name: 'Dave',
+        age: 23
+      }, {
+        name: 'Dave',
+        age: 32
+      }, {
+        name: 'Dada',
+        age: 1
+      }]);
+
+      return app.service('/people').find({
+        query: {
+          $and: [{
+            $or: [
+              {name: 'Dave'},
+              {name: 'Dada'}
+            ]
+          }, {
+            age: {$lt: 23}
+          }]
+        }
+      }).then(data => {
+        expect(data.length).to.equal(1);
+        expect(data[0].name).to.be.equal('Dada');
+        expect(data[0].age).to.be.equal(1);
+        app.service('/people').remove(null);
+      });
+    });
+
     it('where conditions support NULL values properly', () => {
       app.service('/people').create([{
         name: 'Dave without age',


### PR DESCRIPTION
My use case for this method is a permissions hook. I want to add restrictions to which record user might `find`. It may be convenient to do by replacing `params.query` with `{$and: [originalQuery, restrictionsQuery]}` in a before hook. Without `$and` it is not trivial to combine two arbitrary queries.