### PR TITLE
Pass returning columns as an array

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -233,7 +233,7 @@ class Service {
   }
 
   _create (data, params) {
-    return this.db(params).insert(data, this.id).then(rows => {
+    return this.db(params).insert(data, [this.id]).then(rows => {
       const id = typeof data[this.id] !== 'undefined' ? data[this.id] : rows[0];
       return this._get(id, params);
     }).catch(errorHandler);


### PR DESCRIPTION
The current version doesn't work for me, the value of `rows` in the changed line is always `[ {} ]`.

Knex documentation also shows an array (though `.returning()` seems to support a single value)

`.insert(data, [returning])`