### PR TITLE
Adds  $notlike operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,26 @@ Through the REST API:
 /messages?text[$like]=Hello%
 ```
 
+### $notlike
+
+The opposite of `$like`; resulting in an SQL condition similar to this: `WHERE some_field NOT LIKE 'X'`
+
+```js
+app.service('messages').find({
+  query: {
+    text: {
+      $notlike: '%bar'
+    }
+  }
+});
+```
+
+Through the REST API:
+
+```
+/messages?text[$notlike]=%bar
+```
+
 ### $ilike
 
 For PostgreSQL only, the keywork $ilike can be used instead of $like to make the match case insensitive. The following query retrieves all messages that start with `hello` (case insensitive):

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,6 +22,7 @@ const OPERATORS = {
   $gt: '>',
   $gte: '>=',
   $like: 'like',
+  $notlike: 'not like',
   $ilike: 'ilike'
 };
 
@@ -40,7 +41,7 @@ class Service extends AdapterService {
 
     super(Object.assign({
       id: 'id',
-      whitelist: whitelist.concat([ '$like', '$ilike', '$and' ])
+      whitelist: whitelist.concat([ '$like', '$notlike', '$ilike', '$and' ])
     }, options));
 
     this.table = options.name;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -213,6 +213,34 @@ describe('Feathers Knex Service', () => {
     });
   });
 
+  describe('$notlike method', () => {
+    let hasMatch;
+    let hasNoMatch;
+
+    beforeEach(async () => {
+      hasMatch = await peopleService.create({
+        name: 'XYZabcZYX'
+      });
+      hasNoMatch = await peopleService.create({
+        name: 'XYZZYX'
+      });
+    });
+
+    afterEach(() => {
+      peopleService.remove(hasMatch.id);
+      peopleService.remove(hasNoMatch.id);
+    });
+
+    it('$notlike in query', async () => {
+      const data = await peopleService.find({
+        query: { name: { $notlike: '%abc%' } }
+      });
+
+      expect(data.length).to.be.equal(1);
+      expect(data[0].name).to.be.equal('XYZZYX');
+    });
+  });
+
   describe('adapter specifics', () => {
     let daves;
 


### PR DESCRIPTION
### Summary

- Adds a `$notlike` operator for `WHERE x NOT LIKE 'y'`
- No open issues related to this PR
- No dependent PRs

Pretty straight-forward PR. Let me know if there are any questions! 