### PR TITLE
Hooks: proper nesting with savepoints, customisation, fix tests

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -1,67 +1,85 @@
 const debug = require('debug')('feathers-knex-transaction');
 
-const RollbackReason = function (error) {
-  this.error = error;
+const ROLLBACK = { rollback: true };
+
+const getKnex = (hook) => {
+  const knex = hook.service.Model;
+
+  return knex && typeof knex.transaction === 'function' ? knex : undefined;
 };
 
-const start = () => {
-  return hook => {
-    if (!hook.service.Model || typeof hook.service.Model.transaction !== 'function') {
-      return Promise.resolve(hook);
-    }
+const start = (options = {}) => {
+  options = Object.assign({ getKnex }, options);
 
-    if (hook.params.transaction) {
-      hook.params.transaction.count += 1;
-      return Promise.resolve(hook);
+  return hook => {
+    const { transaction } = hook.params;
+    const knex = transaction ? transaction.trx : options.getKnex(hook);
+
+    if (!knex) {
+      return;
     }
 
     return new Promise((resolve, reject) => {
-      const id = Date.now();
+      const transaction = {};
 
-      debug('started a new transaction %s', id);
-      hook.service.Model
-        .transaction(trx => resolve({
-          id,
-          trx,
-          count: 0
-        }))
-        .catch(err => reject(err));
-    }).then(trx => {
-      hook.params.transaction = trx;
-      return hook;
+      transaction.starting = true;
+      transaction.promise = knex.transaction(trx => {
+        transaction.trx = trx;
+        transaction.id = Date.now();
+
+        hook.params.transaction = transaction;
+
+        debug('started a new transaction %s', transaction.id);
+
+        resolve();
+      }).catch((error) => {
+        if (transaction.starting) {
+          reject(error);
+        } else if (error !== ROLLBACK) {
+          throw error;
+        }
+      });
     });
   };
 };
 
 const end = () => {
   return hook => {
-    if (hook.params.transaction) {
-      const { trx, id, count } = hook.params.transaction;
+    const { transaction } = hook.params;
 
-      if (count > 0) {
-        hook.params.transaction.count -= 1;
-        return Promise.resolve(hook);
-      }
-
-      hook.params.transaction = undefined;
-
-      return trx.commit()
-        .then(() => debug('finished transaction %s with success', id))
-        .then(() => hook);
+    if (!transaction) {
+      return;
     }
-    return hook;
+
+    const { trx, id, promise } = transaction;
+
+    hook.params.transaction = undefined;
+    transaction.starting = false;
+
+    return trx.commit()
+      .then(() => promise)
+      .then(() => debug('ended transaction %s', id))
+      .then(() => hook);
   };
 };
 
 const rollback = () => {
   return hook => {
-    if (hook.params.transaction) {
-      const { trx, id } = hook.params.transaction;
-      return trx.rollback(new RollbackReason(hook.error))
-        .then(() => debug('rolling back transaction %s', id))
-        .then(() => hook);
+    const { transaction } = hook.params;
+
+    if (!transaction) {
+      return;
     }
-    return hook;
+
+    const { trx, id, promise } = transaction;
+
+    hook.params.transaction = undefined;
+    transaction.starting = false;
+
+    return trx.rollback(ROLLBACK)
+      .then(() => promise)
+      .then(() => debug('rolled back transaction %s', id))
+      .then(() => hook);
   };
 };
 

--- a/test/service-method-overrides.test.js
+++ b/test/service-method-overrides.test.js
@@ -67,7 +67,7 @@ function attachSchema () {
   return db.schema.raw(`attach database '${schemaName}.sqlite' as ${schemaName}`);
 }
 
-describe.only('Feathers Knex Overridden Method With Self-Join', () => {
+describe('Feathers Knex Overridden Method With Self-Join', () => {
   let ancestor;
   let animal;
 


### PR DESCRIPTION
Instead of simply incrementing a counter `start` hook creates a nested transaction with a savepoint. Counter way fails with complex scenarios like new third test for hooks.

Added `getKnex` option for `start` hook. Allows to specify where to get knex from, so the hook can be used not only with `feathers-knex` service. Useful for `feathers-objection` and tests.

Fixed previous test and added two additional. Previous test was actually not working, it was passing simply because "people2" table was not existent. And initial design of replacing "COMMIT;" with "COMMITA;" was a mistake because a connection was not released afterwards (it was working initially because it was the last test, but stopped to be in #181).


Remark on history: as i understand in an attempt to fix the problem caused by the broken test #181 included a removal of some lines in `hooks.js` ([a](https://github.com/feathersjs-ecosystem/feathers-knex/pull/181/files#diff-177222fb002f2b5e6415844ba4a76772L39), [b](https://github.com/feathersjs-ecosystem/feathers-knex/pull/181/files#diff-177222fb002f2b5e6415844ba4a76772L49), [c](https://github.com/feathersjs-ecosystem/feathers-knex/pull/181/files#diff-177222fb002f2b5e6415844ba4a76772L60), [d](https://github.com/feathersjs-ecosystem/feathers-knex/pull/181/files#diff-177222fb002f2b5e6415844ba4a76772L63)), that caused regression in unhandled rejections, so #196 was needed. It had advantage over initial solution in handling rejections from an establishing phase, but ate rejections from an execution phase (this should have been visible if the broken test was working and not turned off in #181). Now both establishing and execution phases should be handled right.