### PR TITLE
fix: postgres should also returning [id]

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -240,10 +240,8 @@ class Service extends AdapterService {
       return Promise.all(data.map(current => this._create(current, params)));
     }
 
-    let returning;
-    if (this.db(params).client.config.client === 'pg') {
-      returning = [this.id];
-    }
+    const returning = this.db(params).client.config.client === 'pg' ? [this.id] : [];
+
     return this.db(params).insert(data, returning).then(rows => {
       const id = data[this.id] !== undefined ? data[this.id] : rows[0];
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -240,7 +240,11 @@ class Service extends AdapterService {
       return Promise.all(data.map(current => this._create(current, params)));
     }
 
-    return this.db(params).insert(data).then(rows => {
+    let returning;
+    if (this.db(params).client.config.client === 'pg') {
+      returning = [this.id];
+    }
+    return this.db(params).insert(data, returning).then(rows => {
       const id = data[this.id] !== undefined ? data[this.id] : rows[0];
 
       return this._get(id, params);


### PR DESCRIPTION
when using feathers-knex with postgres, .create() method will show error:

> "Undefined binding(s) detected when compiling WHERE query: where \"users\".\"id\" = ?"

that because postgres will not return [id] if not explicitly requested in insert(data, [returning])
[http://knexjs.org/#Builder-insert](http://knexjs.org/#Builder-insert)

this PR will check if current knex object is using postgres or not, then add [id] as returning options to insert() method.