### PR TITLE
Fix _create for oracledb client

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -236,18 +236,22 @@ class Service extends AdapterService {
     }).catch(errorHandler);
   }
 
-  _create (data, params = {}) {
+  _create(data, params = {}) {
     if (Array.isArray(data)) {
       return Promise.all(data.map(current => this._create(current, params)));
     }
 
-    const returning = this.db(params).client.config.client === 'pg' ? [this.id] : [];
+    const client = this.db(params).client.config.client;
+    const returning = client === "pg" || client === "oracledb" ? [this.id] : [];
 
-    return this.db(params).insert(data, returning).then(rows => {
-      const id = data[this.id] !== undefined ? data[this.id] : rows[0];
+    return this.db(params)
+      .insert(data, returning)
+      .then(rows => {
+        const id = data[this.id] !== undefined ? data[this.id] : rows[0];
 
-      return this._get(id, params);
-    }).catch(errorHandler);
+        return this._get(id, params);
+      })
+      .catch(errorHandler);
   }
 
   _patch (id, raw, params = {}) {


### PR DESCRIPTION
The _create  method was throwing an error because oracledb insert was returning the counting of inserted rows instead of an array with the inserted rows id. The fix consists in adding a clause to set the "returning" parameter of insert to ["id"].

### Summary

(If you have not already please refer to the contributing guideline as [described
here](https://github.com/feathersjs/feathers/blob/master/.github/contributing.md#pull-requests))

- [* ] Tell us about the problem your pull request is solving.
- [ ] Are there any open issues that are related to this?
- [ ] Is this PR dependent on PRs in other repos?

If so, please mention them to keep the conversations linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Your PR will be reviewed by a core team member and they will work with you to get your changes merged in a timely manner. If merged your PR will automatically be added to the changelog in the next release.

If your changes involve documentation updates please mention that and link the appropriate PR in [feathers-docs](https://github.com/feathersjs/feathers-docs).

Thanks for contributing to Feathers! :heart: