### PR TITLE
add $contains, $contained_by, and $overlap operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,66 @@ Through the REST API:
 /messages?text[$ilike]=hello%
 ```
 
+### $contains
+
+For PostgreSQL only, for array-type fields, finds records that contain _all_ of the given values. The following query retrieves all messages whose labels contain all of the values `important`, `work`, or `urgent` :
+
+```js
+app.service('messages').find({
+  query: {
+    labels: {
+      $contains: ['important', 'work', 'urgent']
+    }
+  }
+});
+```
+
+Through the REST API:
+
+```
+/messages?label[$contains][0]=important&label[$contains][1]=work&label[$contains][2]=urgent
+```
+
+### $contained_by
+
+For PostgreSQL only, for array-type fields, finds records that are contained by the given list of values, i.e do not contain values other than those given. The following query retrieves all messages whose labels contain any of the values `important`, `work`, or `urgent`, but no values outside that list :
+
+```js
+app.service('messages').find({
+  query: {
+    labels: {
+      $contained_by: ['important', 'work', 'urgent']
+    }
+  }
+});
+```
+
+Through the REST API:
+
+```
+/messages?label[$contained_by][0]=important&label[$contained_by][1]=work&label[$contained_by][2]=urgent
+```
+
+### $overlap
+
+For PostgreSQL only, for array-type fields, finds records that overlap (have points in common) with the given values. The following query retrieves all messages whose labels contain one or more of the values `important`, `work`, or `urgent` :
+
+```js
+app.service('messages').find({
+  query: {
+    labels: {
+      $overlap: ['important', 'work', 'urgent']
+    }
+  }
+});
+```
+
+Through the REST API:
+
+```
+/messages?label[$overlap][0]=important&label[$overlap][1]=work&label[$overlap][2]=urgent
+```
+
 
 ## Transaction Support
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,10 @@ const OPERATORS = {
   $gte: '>=',
   $like: 'like',
   $notlike: 'not like',
-  $ilike: 'ilike'
+  $ilike: 'ilike',
+  $overlap: '&&',
+  $contains: '@>',
+  $contained_by: '<@'
 };
 
 // Create the service.
@@ -42,8 +45,8 @@ class Service extends AdapterService {
     super(Object.assign({
       id: 'id'
     }, options, {
-      whitelist: whitelist.concat(['$like', '$notlike', '$ilike', '$and'])
-    }));
+        whitelist: whitelist.concat(['$like', '$notlike', '$ilike', '$and', '$overlap', '$contains', '$contained_by'])
+      }));
 
     this.table = options.name;
     this.schema = options.schema;


### PR DESCRIPTION
### Summary
Simply adds 3 new array-type operators to OPERATORS and whitelist, as well as documentation

- [ ] Tell us about the problem your pull request is solving
Currently, interacting with array-type fields would require complex and/or queries
- [ ] Are there any open issues that are related to this?
Issue #235 
- [ ] Is this PR dependent on PRs in other repos?
No

### Other Information
Tested to confirm queries are written as expected
