### PR TITLE
Add support for setting `schema` in hook params

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -64,7 +64,8 @@ class Service extends AdapterService {
   // NOTE (EK): We need this method so that we return a new query
   // instance each time, otherwise it will reuse the same query.
   db (params = {}) {
-    const { knex, table, schema, fullName } = this;
+    const { knex, table, fullName } = this;
+    const schema = params.schema || this.schema;
     if (params.transaction) {
       const { trx, id } = params.transaction;
       debug('ran %s with transaction %s', fullName, id);


### PR DESCRIPTION
### Summary


- [X] Tell us about the problem your pull request is solving.
Allow a user to set the schema a request will use by setting `params.schema` within a hook. This matches the API in `feathers-objection`

- [ ] Are there any open issues that are related to this?
No

- [ ] Is this PR dependent on PRs in other repos?
No

If so, please mention them to keep the conversations linked together.

### Other Information

This PR is here so I remember to get back to it. 

Outstanding Tasks:
- [] Document this parameter in the README.md
- [] Create a test for this usecase