### PR TITLE
Put the caller's transaction back in the params on end/rollback

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -13,7 +13,7 @@ const start = (options = {}) => {
 
   return hook => {
     const { transaction } = hook.params;
-    const parent = transaction
+    const parent = transaction;
     const knex = transaction ? transaction.trx : options.getKnex(hook);
 
     if (!knex) {
@@ -24,7 +24,12 @@ const start = (options = {}) => {
       const transaction = {};
 
       if (parent) {
-        transaction.parent = parent
+        transaction.parent = parent;
+        transaction.committed = parent.committed;
+      } else {
+        transaction.committed = new Promise(resolve => {
+          transaction.resolve = resolve;
+        });
       }
 
       transaction.starting = true;
@@ -63,6 +68,7 @@ const end = () => {
 
     return trx.commit()
       .then(() => promise)
+      .then(() => transaction.resolve && transaction.resolve(true))
       .then(() => debug('ended transaction %s', id))
       .then(() => hook);
   };
@@ -83,6 +89,7 @@ const rollback = () => {
 
     return trx.rollback(ROLLBACK)
       .then(() => promise)
+      .then(() => transaction.resolve && transaction.resolve(false))
       .then(() => debug('rolled back transaction %s', id))
       .then(() => hook);
   };

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -13,6 +13,7 @@ const start = (options = {}) => {
 
   return hook => {
     const { transaction } = hook.params;
+    const parent = transaction
     const knex = transaction ? transaction.trx : options.getKnex(hook);
 
     if (!knex) {
@@ -21,6 +22,10 @@ const start = (options = {}) => {
 
     return new Promise((resolve, reject) => {
       const transaction = {};
+
+      if (parent) {
+        transaction.parent = parent
+      }
 
       transaction.starting = true;
       transaction.promise = knex.transaction(trx => {
@@ -51,9 +56,9 @@ const end = () => {
       return;
     }
 
-    const { trx, id, promise } = transaction;
+    const { trx, id, promise, parent } = transaction;
 
-    hook.params = { ...hook.params, transaction: undefined };
+    hook.params = { ...hook.params, transaction: parent };
     transaction.starting = false;
 
     return trx.commit()
@@ -71,9 +76,9 @@ const rollback = () => {
       return;
     }
 
-    const { trx, id, promise } = transaction;
+    const { trx, id, promise, parent } = transaction;
 
-    hook.params = { ...hook.params, transaction: undefined };
+    hook.params = { ...hook.params, transaction: parent };
     transaction.starting = false;
 
     return trx.rollback(ROLLBACK)


### PR DESCRIPTION
Not 100% confident this is correct, but here's my reasoning.

In my service.publish() publishers I want to await for `transaction.promise`, so that events only get emitted once the transaction, if any, is succesfully committed.

I can do that like this:

```js
app.service('messages').publish((data, context) => {
  const { transaction } = context.params

  if (transaction) {
    try {
      await transaction.promise
    } catch (err) {
      return []
    }
  }

  return app.channel(`rooms/${data.roomId}`)
})
```

This works well if the service creates/updates other services in an after hook, forwarding the transcation as a param. The nested/related services will create things under that shared transaction, and will also await on the params.transaction.promise (in the publisher), before they send out the realtime events.

However, if the "nested" service also creates a transaction, that works well with respect to the DB queries, but in the `transcation.end` / `transaction.rollback`, it wipes the params.transaction, and the service loses the knowledge it was inside a transaction. So the event publisher can no longer await for that transaction.promise.

The idea is that any after hooks or event publishers inspecting params.transaction, should work the same regardless of whether the service has an intermediate transcation or not.