### PR TITLE
Fix id extraction in id

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -230,7 +230,15 @@ class Service extends AdapterService {
     return this.db(params)
       .insert(data, returning)
       .then(rows => {
-        const id = data[this.id] !== undefined ? data[this.id] : rows[0];
+        let id
+
+        if (data[this.id] !== undefined) {
+          id = data[this.id]
+        } else if (rows[0] && rows[0][this.id]) {
+          id = rows[0][this.id]
+        }
+
+        if (!id) return rows
 
         return this._get(id, params);
       })

--- a/lib/index.js
+++ b/lib/index.js
@@ -234,6 +234,8 @@ class Service extends AdapterService {
 
         if (data[this.id] !== undefined) {
           id = data[this.id]
+        } else if (!returning.length) {
+          id = rows[0]
         } else if (rows[0] && rows[0][this.id]) {
           id = rows[0][this.id]
         }


### PR DESCRIPTION
In knex, db.insert(data, ['id']) returns an array of objects in the shape of [{ id }, { id }]. Referencing `rows[0]` gives you `{ id }`, and that means we call `this._get({ id })`, when we meant to call `this._get(id)`. This still works! Because of knexify manages to turn that into a valid query, but I'm not sure that's intended? We just want to call `_get(id)` from the get go. This doesn't really change the outcome, but confused me for a while when debugging another issue, and this change could prevent future problems in case `feathers-knex` or `knex` code changes in some way.