### PR TITLE
Update Knex Typescript definition import.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,7 @@
 // TypeScript Version: 3.7
 import { Params, Paginated, Id, NullableId, HookContext, Hook } from '@feathersjs/feathers';
 import { AdapterService, ServiceOptions, InternalServiceMethods } from '@feathersjs/adapter-commons';
-import * as Knex from 'knex';
+import { Knex } from 'knex';
 import { start } from 'repl';
 
 export interface KnexServiceOptions extends ServiceOptions {


### PR DESCRIPTION
Knex 0.95.x changed the Typescript definition import. (https://github.com/knex/knex/blob/master/UPGRADING.md)
This causes new Feathers-Knex Typescript projects to fail on a newly generated project.

### Solution
Update Knex type definition import for 0.95.x.

### Summary
- [x] Tell us about the problem your pull request is solving.
- [x] Are there any open issues that are related to this?
https://github.com/feathersjs-ecosystem/feathers-knex/issues/259
- [ ] Is this PR dependent on PRs in other repos?

### Screenshots
<img width="898" alt="Screen Shot 2021-06-30 at 8 33 07 PM" src="https://user-images.githubusercontent.com/1027918/124056127-62e5dd80-d9e2-11eb-90e9-ed1005ab60ed.png">