### PR TITLE
Fix regression of PR #257 to fix create for mssql

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -235,10 +235,8 @@ class Service extends AdapterService {
 
         if (data[this.id] !== undefined) {
           id = data[this.id];
-        } else if (!returning.length) {
-          id = rows[0];
-        } else if (rows[0] && rows[0][this.id]) {
-          id = rows[0][this.id];
+        } else if (rows[0]) {
+          id = rows[0][this.id] !== undefined ? rows[0][this.id] : rows[0];
         }
 
         if (!id) return rows;


### PR DESCRIPTION
### Summary

The fix introduced in #257 breaks create when using mssql.

When using mssql knex' db.insert does not return an array of objects, but an array of numbers.